### PR TITLE
Add region and platform models in reporting layer

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -15,6 +15,8 @@ vars:
     ad_history: "{{ ref('stg_facebook_ads__ad_history') }}"
     ad_set_history: "{{ ref('stg_facebook_ads__ad_set_history') }}"
     basic_ad: "{{ ref('stg_facebook_ads__basic_ad') }}"
+    basic_ad_region: "{{ ref('stg_facebook_ads__basic_ad_region') }}"
+    basic_ad_platform: "{{ ref('stg_facebook_ads__basic_ad_platform') }}"
     campaign_history: "{{ ref('stg_facebook_ads__campaign_history') }}"
     creative_history: "{{ ref('stg_facebook_ads__creative_history') }}"
     url_tag: "{{ ref('stg_facebook_ads__url_tag') }}"

--- a/models/facebook_ads__ad_platform_report.sql
+++ b/models/facebook_ads__ad_platform_report.sql
@@ -1,0 +1,73 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with report as (
+
+    select *
+    from {{ var('basic_ad_platform') }}
+
+),
+
+accounts as (
+
+    select *
+    from {{ var('account_history') }}
+    where is_most_recent_record = true
+
+),
+
+campaigns as (
+
+    select *
+    from {{ var('campaign_history') }}
+    where is_most_recent_record = true
+
+),
+
+ad_sets as (
+
+    select *
+    from {{ var('ad_set_history') }}
+    where is_most_recent_record = true
+
+),
+
+ads as (
+
+    select *
+    from {{ var('ad_history') }}
+    where is_most_recent_record = true
+
+),
+
+joined as (
+
+    select
+        report.date_day,
+        accounts.account_id,
+        accounts.account_name,
+        campaigns.campaign_id,
+        campaigns.campaign_name,
+        ad_sets.ad_set_id,
+        ad_sets.ad_set_name,
+        ads.ad_id,
+        ads.ad_name,
+        report.platform,
+        sum(report.clicks) as clicks,
+        sum(report.impressions) as impressions,
+        sum(report.spend) as spend
+
+        {{ fivetran_utils.persist_pass_through_columns(pass_through_variable='facebook_ads__basic_ad_passthrough_metrics', transform = 'sum') }}
+    from report
+    left join accounts
+        on report.account_id = accounts.account_id
+    left join ads
+        on report.ad_id = ads.ad_id
+    left join campaigns
+        on ads.campaign_id = campaigns.campaign_id
+    left join ad_sets
+        on ads.ad_set_id = ad_sets.ad_set_id
+    {{ dbt_utils.group_by(10) }}
+)
+
+select *
+from joined

--- a/models/facebook_ads__ad_region_report.sql
+++ b/models/facebook_ads__ad_region_report.sql
@@ -1,0 +1,73 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with report as (
+
+    select *
+    from {{ var('basic_ad_region') }}
+
+),
+
+accounts as (
+
+    select *
+    from {{ var('account_history') }}
+    where is_most_recent_record = true
+
+),
+
+campaigns as (
+
+    select *
+    from {{ var('campaign_history') }}
+    where is_most_recent_record = true
+
+),
+
+ad_sets as (
+
+    select *
+    from {{ var('ad_set_history') }}
+    where is_most_recent_record = true
+
+),
+
+ads as (
+
+    select *
+    from {{ var('ad_history') }}
+    where is_most_recent_record = true
+
+),
+
+joined as (
+
+    select
+        report.date_day,
+        accounts.account_id,
+        accounts.account_name,
+        campaigns.campaign_id,
+        campaigns.campaign_name,
+        ad_sets.ad_set_id,
+        ad_sets.ad_set_name,
+        ads.ad_id,
+        ads.ad_name,
+        report.region,
+        sum(report.clicks) as clicks,
+        sum(report.impressions) as impressions,
+        sum(report.spend) as spend
+
+        {{ fivetran_utils.persist_pass_through_columns(pass_through_variable='facebook_ads__basic_ad_passthrough_metrics', transform = 'sum') }}
+    from report
+    left join accounts
+        on report.account_id = accounts.account_id
+    left join ads
+        on report.ad_id = ads.ad_id
+    left join campaigns
+        on ads.campaign_id = campaigns.campaign_id
+    left join ad_sets
+        on ads.ad_set_id = ad_sets.ad_set_id
+    {{ dbt_utils.group_by(10) }}
+)
+
+select *
+from joined

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fivetran/facebook_ads_source
-    version: [">=0.5.0", "<0.6.0"]
+  - local: /Users/bsorensen/Projects/packages/dbt_facebook_ads_source
+    # version: [">=0.5.0", "<0.6.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - local: /Users/bsorensen/Projects/packages/dbt_facebook_ads_source
-    # version: [">=0.5.0", "<0.6.0"]
+  - git: "https://github.com/aclu-national/dbt_facebook_ads_source.git"
+    revision: "bsorensen-fb-source-fork"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/aclu-national/dbt_facebook_ads_source.git"
-    revision: "bsorensen-fb-source-fork"
+    revision: "main"


### PR DESCRIPTION
Modifies Fivetran's Facebook Ads reporting package to introduce ad-platform and ad-region level granularity, building upon the modifications to the `aclu-national/dbt_facebook_ads_source` package. Both of these reports are essentially slimmed down variations on the basic_ad report. 