### PR TITLE
Combine BPI backfill data with existing report

### DIFF
--- a/models/facebook_ads__ad_set_report.sql
+++ b/models/facebook_ads__ad_set_report.sql
@@ -15,12 +15,12 @@ backfill as (
 
 unioned as (
 
-    select * 
+    select *, 'Fivetran' as sync_source
     from intermediate
 
     union 
 
-    select * 
+    select *, 'Backfill' as sync_source
     from backfill 
 )
 

--- a/models/facebook_ads__ad_set_report.sql
+++ b/models/facebook_ads__ad_set_report.sql
@@ -1,75 +1,29 @@
 {{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
 
-with report as (
+with intermediate as (
 
     select *
-    from {{ var('basic_ad') }}
+    from {{ ref('int_facebook_ads__ad_set_report') }}
 
 ), 
 
-accounts as (
+backfill as (
 
-    select *
-    from {{ var('account_history') }}
-    where is_most_recent_record = true
-
+    select * 
+    from {{ ref('stg_facebook_ads__bpi_backfill__ad_set_report') }}
 ),
 
-campaigns as (
+unioned as (
 
-    select *
-    from {{ var('campaign_history') }}
-    where is_most_recent_record = true
+    select * 
+    from intermediate
 
-),
+    union 
 
-ad_sets as (
-
-    select *
-    from {{ var('ad_set_history') }}
-    where is_most_recent_record = true
-
-),
-
-ads as (
-
-    select *
-    from {{ var('ad_history') }}
-    where is_most_recent_record = true
-
-),
-
-joined as (
-
-    select 
-        report.date_day,
-        accounts.account_id,
-        accounts.account_name,
-        campaigns.campaign_id,
-        campaigns.campaign_name,
-        ad_sets.ad_set_id,
-        ad_sets.ad_set_name,
-        ad_sets.start_at,
-        ad_sets.end_at,
-        ad_sets.bid_strategy,
-        ad_sets.daily_budget,
-        ad_sets.budget_remaining,
-        sum(report.clicks) as clicks,
-        sum(report.impressions) as impressions,
-        sum(report.spend) as spend
-
-        {{ fivetran_utils.persist_pass_through_columns(pass_through_variable='facebook_ads__basic_ad_passthrough_metrics', transform = 'sum') }}
-    from report 
-    left join accounts
-        on report.account_id = accounts.account_id
-    left join ads 
-        on report.ad_id = ads.ad_id
-    left join campaigns
-        on ads.campaign_id = campaigns.campaign_id
-    left join ad_sets
-        on ads.ad_set_id = ad_sets.ad_set_id
-    {{ dbt_utils.group_by(12) }}
+    select * 
+    from backfill 
 )
 
-select *
-from joined
+select * 
+from unioned 
+order by date_day 

--- a/models/intermediate/int_facebook_ads__ad_set_report.sql
+++ b/models/intermediate/int_facebook_ads__ad_set_report.sql
@@ -1,0 +1,75 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with report as (
+
+    select *
+    from {{ var('basic_ad') }}
+
+), 
+
+accounts as (
+
+    select *
+    from {{ var('account_history') }}
+    where is_most_recent_record = true
+
+),
+
+campaigns as (
+
+    select *
+    from {{ var('campaign_history') }}
+    where is_most_recent_record = true
+
+),
+
+ad_sets as (
+
+    select *
+    from {{ var('ad_set_history') }}
+    where is_most_recent_record = true
+
+),
+
+ads as (
+
+    select *
+    from {{ var('ad_history') }}
+    where is_most_recent_record = true
+
+),
+
+joined as (
+
+    select 
+        report.date_day,
+        accounts.account_id,
+        accounts.account_name,
+        campaigns.campaign_id,
+        campaigns.campaign_name,
+        ad_sets.ad_set_id,
+        ad_sets.ad_set_name,
+        ad_sets.start_at,
+        ad_sets.end_at,
+        ad_sets.bid_strategy,
+        ad_sets.daily_budget,
+        ad_sets.budget_remaining,
+        sum(report.clicks) as clicks,
+        sum(report.impressions) as impressions,
+        sum(report.spend) as spend
+
+        {{ fivetran_utils.persist_pass_through_columns(pass_through_variable='facebook_ads__basic_ad_passthrough_metrics', transform = 'sum') }}
+    from report 
+    left join accounts
+        on report.account_id = accounts.account_id
+    left join ads 
+        on report.ad_id = ads.ad_id
+    left join campaigns
+        on ads.campaign_id = campaigns.campaign_id
+    left join ad_sets
+        on ads.ad_set_id = ad_sets.ad_set_id
+    {{ dbt_utils.group_by(12) }}
+)
+
+select *
+from joined

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/aclu-national/dbt_facebook_ads_source.git"
-    revision: "main"
+    revision: "aclu-main"


### PR DESCRIPTION
- The `stg_facebook_ads__bpi_backfill__ad_set_report` model is defined in https://github.com/aclu-national/dbt_facebook_ads_source/pull/3 and mirrors the existing `facebook_ads__ad_set_report` model in this repo
- The original `facebook_ads__ad_set_report` model (which models the Fivetran-synced data) is moved as-is to an intermediate model, `int_facebook_ads__ad_set_report`
- This intermediate model is unioned with the backfill to create the combined `facebook_ads__ad_set_report` model, including both the Fivetran-synced data and BPI backfill data.
- The branch specified for package installation is switched to `aclu-main` to silence warnings about using `main` branch that result when running `dbt deps` 

Full DAG:
![image](https://user-images.githubusercontent.com/37889665/207155604-68d0d280-b3a0-4c7f-a503-aab416a3ef1c.png)

Zoomed in on changes: 
![image](https://user-images.githubusercontent.com/37889665/207155845-118744c3-3c5b-43df-9281-78a0275aa835.png)
