### PR TITLE
New BPI Backfills

### DIFF
--- a/models/facebook.yml
+++ b/models/facebook.yml
@@ -202,3 +202,56 @@ models:
         description: The value assigned to the url tag object associated with this record.
       - name: type
         description: The type assigned to the url tag object e.g. 'AD_VIDEO'.
+
+  - name: facebook_ads__ad_set_platform_report
+    description: Each record represents the platform-specific daily performance of an ad set. Combines Fivetran-synced data with backfilled BPI data. 
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date_day
+            - account_name
+            - campaign_name
+            - ad_set_name 
+            - platform 
+    columns:
+      - name: date_day
+        description: The date of the performance.
+      - name: account_name
+        description: The name of the related account.
+      - name: campaign_name
+        description: The name of the related campaign.
+      - name: platform
+        description: The platform through which the ad set was served (Facebook or Instagram).
+      - name: ad_set_name
+        description: The name of the related ad set.
+      - name: impressions
+        description: The number of impressions the ad set had on the given day.
+      - name: spend
+        description: The spend on the ad set in the given day.
+
+  - name: facebook_ads__ad_set_region_report
+    description: Each record represents the region-specific daily performance of an ad set. Combines Fivetran-synced data with backfilled BPI data. 
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date_day
+            - account_name
+            - campaign_name
+            - ad_set_name 
+            - region 
+    columns:
+      - name: date_day
+        description: The date of the performance.
+      - name: account_name
+        description: The name of the related account.
+      - name: campaign_name
+        description: The name of the related campaign.
+      - name: region
+        description: The region (state) in which the ad set was served.
+      - name: ad_set_name
+        description: The name of the related ad set.
+      - name: impressions
+        description: The number of impressions the ad set had on the given day.
+      - name: spend
+        description: The spend on the ad set in the given day.
+      

--- a/models/facebook_ads__ad_set_platform_report.sql
+++ b/models/facebook_ads__ad_set_platform_report.sql
@@ -1,0 +1,44 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with ad_report as (
+
+    select
+        date_day
+        ,account_name
+	    ,campaign_name
+	    ,ad_set_name
+	    ,platform
+	    ,sum(impressions) as impressions
+	    ,sum(spend) as spend
+    from {{ ref('facebook_ads__ad_platform_report') }}
+     {{ dbt_utils.group_by(5) }}
+
+), 
+
+backfill as (
+
+    select 	
+        date_day
+        ,'ACLU Liberty Watch (BPI)' as account_name
+	    ,campaign_name
+	    ,ad_set_name
+	    ,platform
+	    ,sum(impressions) as impressions
+	    ,sum(spend) as spend
+    from {{ ref('stg_facebook_ads__bpi_backfill__ad_set_platform_report') }}
+    {{ dbt_utils.group_by(5) }}
+),
+
+unioned as (
+
+    select *
+    from ad_report 
+
+    union 
+
+    select * 
+    from backfill 
+
+)
+
+select * from unioned

--- a/models/facebook_ads__ad_set_region_report.sql
+++ b/models/facebook_ads__ad_set_region_report.sql
@@ -1,0 +1,44 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with ad_report as (
+
+    select
+        date_day
+        ,account_name
+	    ,campaign_name
+	    ,ad_set_name
+	    ,region
+	    ,sum(impressions) as impressions
+	    ,sum(spend) as spend
+    from {{ ref('facebook_ads__ad_region_report') }}
+     {{ dbt_utils.group_by(5) }}
+
+), 
+
+backfill as (
+
+    select 	
+        date_day
+        ,'ACLU Liberty Watch (BPI)' as account_name
+	    ,campaign_name
+	    ,ad_set_name
+	    ,region
+	    ,sum(impressions) as impressions
+	    ,sum(spend) as spend
+    from {{ ref('stg_facebook_ads__bpi_backfill__ad_set_region_report') }}
+    {{ dbt_utils.group_by(5) }}
+),
+
+unioned as (
+
+    select *
+    from ad_report 
+
+    union 
+
+    select * 
+    from backfill 
+
+)
+
+select * from unioned


### PR DESCRIPTION
- Aggregates the new staging models with backfill data at the day/campaign/ad-set/region (or platform) level to combine with the existing ads report. 
- Ibrahim needs this backfill data for the MMM project. 